### PR TITLE
料金セクションに予約ボタンを追加

### DIFF
--- a/fukuoka/2025/tesshie_vtryo_night/index.html
+++ b/fukuoka/2025/tesshie_vtryo_night/index.html
@@ -195,8 +195,8 @@
                 <h3>お支払い方法</h3>
                 <p class="content-center">現金、PayPayがご利用いただけます。</p>
             </div>
-            <div class="reservation-button">
-                <p class="reservation-closed">※予約は締め切られました</p>
+           <div class="reservation-form-container">
+                <a href="https://forms.gle/ds3V8zc3MdCAjQzq5" target="_blank" class="reservation-button">予約する</a>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## 概要
料金セクションで予約締切メッセージを予約ボタンに変更し、ユーザーが予約フォームにアクセスしやすくしました。

## 変更内容
- **予約ボタン追加**: 料金セクションの「※予約は締め切られました」メッセージを予約ボタンに変更
- **一貫性向上**: ヒーローセクションと同じスタイリングの予約ボタンを使用
- **利便性向上**: Google Formsへの直接リンクで予約プロセスを簡素化

## テスト確認項目
- [x] 料金セクションに予約ボタンが表示される
- [x] ボタンがGoogle Formsの正しいURLにリンクしている
- [x] 新しいタブで開く動作
- [x] ホバーアニメーションが動作する
- [x] モバイル表示での見た目

🤖 Generated with [Claude Code](https://claude.ai/code)