### PR TITLE
feat: display course pricing and drink charge information

### DIFF
--- a/fukuoka/2025/tesshie_vtryo_night/index.html
+++ b/fukuoka/2025/tesshie_vtryo_night/index.html
@@ -188,7 +188,8 @@
             <div class="pricing-container">
                 <div class="pricing-card">
                     <h3>コース料理</h3>
-                    <div class="price">未定</div>
+                    <div class="price">5,000円</div>
+                    <p class="price-note">※お飲み物は別途料金になります</p>
                 </div>
             </div>
             <div class="payment-info">

--- a/fukuoka/2025/tesshie_vtryo_night/style.css
+++ b/fukuoka/2025/tesshie_vtryo_night/style.css
@@ -751,9 +751,19 @@ section
     font-size: 2.5rem;
     font-weight: 700;
 
-    margin-bottom: 1.5rem;
+    margin-bottom: 1rem;
 
     color: var(--secondary-color);
+}
+
+.price-note
+{
+    font-size: 0.9rem;
+    font-style: italic;
+
+    margin-bottom: 1.5rem;
+
+    color: var(--text-light);
 }
 
 .tax-info


### PR DESCRIPTION
Updates the event website pricing section to display course pricing information.

## Changes
- Updated pricing from "未定" to "5,000円" for course meals
- Added notice that drinks are charged separately
- Added CSS styling for price note to maintain clean layout
- Maintained existing layout and readability

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/code)